### PR TITLE
Fixed event timezone conversion. Added better display for event time in embed

### DIFF
--- a/src/main/java/com/bp3x/raidbot/commands/LFGCommand.java
+++ b/src/main/java/com/bp3x/raidbot/commands/LFGCommand.java
@@ -82,7 +82,7 @@ public class LFGCommand extends Command {
                     .ofPattern(TIMESTAMP_PATTERN)
                     .withZone(ZoneId.of(zoneId));
             eventDateTime = ZonedDateTime.from(userTimestampFormatter.parse(dateTimeString));
-            eventDateTime.withZoneSameInstant(ZoneId.of("GMT"));
+            eventDateTime = eventDateTime.withZoneSameInstant(ZoneId.of("GMT"));
 
             if (eventDateTime.isBefore(ZonedDateTime.now())) {
                 event.getChannel().sendMessage("Cannot schedule an event in the past.").queue();

--- a/src/main/java/com/bp3x/raidbot/commands/util/LFGEmbedBuilder.java
+++ b/src/main/java/com/bp3x/raidbot/commands/util/LFGEmbedBuilder.java
@@ -21,7 +21,11 @@ public class LFGEmbedBuilder extends RaidBotEmbedBuilder {
 
     public LFGEmbedBuilder(Event plannedEvent) {
         this.setTitle(plannedEvent.getLongName());
-        this.setTimestamp(plannedEvent.getTime());
+
+        String timestamp = "<t:" +
+                plannedEvent.getTime().toEpochSecond() +
+                ":F>";
+        this.addField("Time", timestamp, false);
 
         String playerCountStringBuilder = "(" +
                 plannedEvent.getAcceptedPlayers().size() +


### PR DESCRIPTION
Fixed bug where event timestamps weren't being converted to GMT properly.

Discord gives us a nice way to display timestamps by providing epoch time. We can use this to display the correct time regardless of the viewer's timezone.