### PR TITLE
Update timing on deletion of messages for the bot

### DIFF
--- a/src/main/java/com/bp3x/raidbot/commands/lfg/DeleteCommand.java
+++ b/src/main/java/com/bp3x/raidbot/commands/lfg/DeleteCommand.java
@@ -39,8 +39,8 @@ public class DeleteCommand extends Command {
         if (args.length == 1) {
             eventToDelete = Event.getEventById(args[0]);
             if (eventToDelete == null) {
-                MessageUtils.sendAutoDeletedMessage(new MessageBuilder().append("Unable to find event message to delete with provided ID, please recheck and try again.").build(), 15, commandEvent.getChannel());
-                MessageUtils.deleteMessage(commandEvent.getMessage());
+                MessageUtils.sendAutoDeletedMessage("Unable to find event message to delete with provided ID, please recheck and try again.", 300, commandEvent.getChannel());
+                MessageUtils.autoDeleteMessage(commandEvent.getMessage(), 300);
                 return;
             }
 
@@ -50,18 +50,18 @@ public class DeleteCommand extends Command {
                 Event.removeEvent(messageToDelete);
             } catch (ErrorResponseException ere) {
                 log.error("Error response exception thrown when deleting message", ere);
-                MessageUtils.sendAutoDeletedMessage(new MessageBuilder().append("The message that you tried to delete may have already been deleted, contact an admin").build(), 15, commandEvent.getChannel());
+                MessageUtils.sendAutoDeletedMessage("The message that you tried to delete may have already been deleted, contact an admin", 300, commandEvent.getChannel());
             } catch (RaidBotRuntimeException e) {
                 log.error("Could not save events to JSON backup!", e);
             }
 
         } else {
-            commandEvent.getChannel().sendMessage("Invalid arguments. Use `!delete <eventID>`").queue();
+           MessageUtils.sendAutoDeletedMessage("Invalid arguments. Use `!delete <eventID>`", 300, commandEvent.getChannel());
         }
         if (eventToDelete != null && messageToDelete != null) {
-            commandEvent.getMessage().delete().queue();
+            MessageUtils.autoDeleteMessage(commandEvent.getMessage(), 300);
             messageToDelete.delete().queue();
-            MessageUtils.sendAutoDeletedMessage(new MessageBuilder().append("Deleted event with ID: ").append(eventToDelete.getEventId()).build(), 15, commandEvent.getChannel());
+            MessageUtils.sendAutoDeletedMessage("Deleted event with ID: " + eventToDelete.getEventId(), 300, commandEvent.getChannel());
         }
     }
 }

--- a/src/main/java/com/bp3x/raidbot/commands/lfg/DeleteCommand.java
+++ b/src/main/java/com/bp3x/raidbot/commands/lfg/DeleteCommand.java
@@ -39,8 +39,7 @@ public class DeleteCommand extends Command {
         if (args.length == 1) {
             eventToDelete = Event.getEventById(args[0]);
             if (eventToDelete == null) {
-                MessageUtils.sendAutoDeletedMessage("Unable to find event message to delete with provided ID, please recheck and try again.", 300, commandEvent.getChannel());
-                MessageUtils.autoDeleteMessage(commandEvent.getMessage(), 300);
+                MessageUtils.sendAutoDeletedMessage("Unable to find event message to delete with provided ID, please recheck and try again.", 300, commandEvent);
                 return;
             }
 
@@ -50,20 +49,18 @@ public class DeleteCommand extends Command {
                 Event.removeEvent(messageToDelete);
             } catch (ErrorResponseException ere) {
                 log.error("Error response exception thrown when deleting message", ere);
-                MessageUtils.sendAutoDeletedMessage("The message that you tried to delete may have already been deleted, contact an admin", 300, commandEvent.getChannel());
-                MessageUtils.autoDeleteMessage(commandEvent.getMessage(), 300);
+                MessageUtils.sendAutoDeletedMessage("The message that you tried to delete may have already been deleted, contact an admin", 300, commandEvent);
             } catch (RaidBotRuntimeException e) {
                 log.error("Could not save events to JSON backup!", e);
             }
 
         } else {
-           MessageUtils.sendAutoDeletedMessage("Invalid arguments. Use `!delete <eventID>`", 300, commandEvent.getChannel());
-           MessageUtils.autoDeleteMessage(commandEvent.getMessage(), 300);
+           MessageUtils.sendAutoDeletedMessage("Invalid arguments. Use `!delete <eventID>`", 300, commandEvent);
         }
         if (eventToDelete != null && messageToDelete != null) {
             MessageUtils.autoDeleteMessage(commandEvent.getMessage(), 300);
             messageToDelete.delete().queue();
-            MessageUtils.sendAutoDeletedMessage("Deleted event with ID: " + eventToDelete.getEventId(), 300, commandEvent.getChannel());
+            MessageUtils.sendAutoDeletedMessage("Deleted event with ID: " + eventToDelete.getEventId(), 300, commandEvent);
         }
     }
 }

--- a/src/main/java/com/bp3x/raidbot/commands/lfg/DeleteCommand.java
+++ b/src/main/java/com/bp3x/raidbot/commands/lfg/DeleteCommand.java
@@ -51,12 +51,14 @@ public class DeleteCommand extends Command {
             } catch (ErrorResponseException ere) {
                 log.error("Error response exception thrown when deleting message", ere);
                 MessageUtils.sendAutoDeletedMessage("The message that you tried to delete may have already been deleted, contact an admin", 300, commandEvent.getChannel());
+                MessageUtils.autoDeleteMessage(commandEvent.getMessage(), 300);
             } catch (RaidBotRuntimeException e) {
                 log.error("Could not save events to JSON backup!", e);
             }
 
         } else {
            MessageUtils.sendAutoDeletedMessage("Invalid arguments. Use `!delete <eventID>`", 300, commandEvent.getChannel());
+           MessageUtils.autoDeleteMessage(commandEvent.getMessage(), 300);
         }
         if (eventToDelete != null && messageToDelete != null) {
             MessageUtils.autoDeleteMessage(commandEvent.getMessage(), 300);

--- a/src/main/java/com/bp3x/raidbot/commands/lfg/LFGCommand.java
+++ b/src/main/java/com/bp3x/raidbot/commands/lfg/LFGCommand.java
@@ -48,15 +48,18 @@ public class LFGCommand extends Command {
         Role userTimezoneRole = commandEvent.getMember().getRoles().stream().filter(timezoneRoles::contains).findFirst().orElse(null);
         if (userTimezoneRole == null) {
             MessageUtils.sendAutoDeletedMessage("You do not have a timezone role assigned. Ask an admin to give you your role.", 300, commandEvent.getChannel());
+            MessageUtils.autoDeleteMessage(commandEvent.getMessage(), 300);
             return;
         }
 
         String[] args = commandEvent.getArgs().split("\\s+");
         if (args.length < 3) {
             MessageUtils.sendAutoDeletedMessage("Missing activity and/or date+time argument(s)", 300, commandEvent.getChannel());
+            MessageUtils.autoDeleteMessage(commandEvent.getMessage(), 300);
             return;
         } else if (args.length > 3) {
-            MessageUtils.sendAutoDeletedMessage("Too many arguments. Should be in the format of: " + this.arguments, 300, commandEvent.getChannel());;
+            MessageUtils.sendAutoDeletedMessage("Too many arguments. Should be in the format of: " + this.arguments, 300, commandEvent.getChannel());
+            MessageUtils.autoDeleteMessage(commandEvent.getMessage(), 300);
             return;
         }
 
@@ -81,10 +84,12 @@ public class LFGCommand extends Command {
 
             if (eventDateTime.isBefore(ZonedDateTime.now())) {
                 MessageUtils.sendAutoDeletedMessage("Cannot schedule an event in the past.", 300, commandEvent.getChannel());
+                MessageUtils.autoDeleteMessage(commandEvent.getMessage(), 300);
                 return;
             }
         } catch (DateTimeParseException e) {
             MessageUtils.sendAutoDeletedMessage("Invalid date/time argument.", 300, commandEvent.getChannel());
+            MessageUtils.autoDeleteMessage(commandEvent.getMessage(), 300);
             return;
         }
 

--- a/src/main/java/com/bp3x/raidbot/commands/lfg/LFGCommand.java
+++ b/src/main/java/com/bp3x/raidbot/commands/lfg/LFGCommand.java
@@ -8,7 +8,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
-import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.requests.RestAction;
@@ -47,19 +46,16 @@ public class LFGCommand extends Command {
         ArrayList<Role> timezoneRoles = RaidBot.getConfig().getTimezoneRoles();
         Role userTimezoneRole = commandEvent.getMember().getRoles().stream().filter(timezoneRoles::contains).findFirst().orElse(null);
         if (userTimezoneRole == null) {
-            MessageUtils.sendAutoDeletedMessage("You do not have a timezone role assigned. Ask an admin to give you your role.", 300, commandEvent.getChannel());
-            MessageUtils.autoDeleteMessage(commandEvent.getMessage(), 300);
+            MessageUtils.sendAutoDeletedMessage("You do not have a timezone role assigned. Ask an admin to give you your role.", 300, commandEvent);
             return;
         }
 
         String[] args = commandEvent.getArgs().split("\\s+");
         if (args.length < 3) {
-            MessageUtils.sendAutoDeletedMessage("Missing activity and/or date+time argument(s)", 300, commandEvent.getChannel());
-            MessageUtils.autoDeleteMessage(commandEvent.getMessage(), 300);
+            MessageUtils.sendAutoDeletedMessage("Missing activity and/or date+time argument(s)", 300, commandEvent);
             return;
         } else if (args.length > 3) {
-            MessageUtils.sendAutoDeletedMessage("Too many arguments. Should be in the format of: " + this.arguments, 300, commandEvent.getChannel());
-            MessageUtils.autoDeleteMessage(commandEvent.getMessage(), 300);
+            MessageUtils.sendAutoDeletedMessage("Too many arguments. Should be in the format of: " + this.arguments, 300, commandEvent);
             return;
         }
 
@@ -83,13 +79,11 @@ public class LFGCommand extends Command {
             eventDateTime = eventDateTime.withZoneSameInstant(ZoneId.of("GMT"));
 
             if (eventDateTime.isBefore(ZonedDateTime.now())) {
-                MessageUtils.sendAutoDeletedMessage("Cannot schedule an event in the past.", 300, commandEvent.getChannel());
-                MessageUtils.autoDeleteMessage(commandEvent.getMessage(), 300);
+                MessageUtils.sendAutoDeletedMessage("Cannot schedule an event in the past.", 300, commandEvent);
                 return;
             }
         } catch (DateTimeParseException e) {
-            MessageUtils.sendAutoDeletedMessage("Invalid date/time argument.", 300, commandEvent.getChannel());
-            MessageUtils.autoDeleteMessage(commandEvent.getMessage(), 300);
+            MessageUtils.sendAutoDeletedMessage("Invalid date/time argument.", 300, commandEvent);
             return;
         }
 
@@ -114,10 +108,10 @@ public class LFGCommand extends Command {
                 MessageUtils.autoDeleteMessage(commandEvent.getMessage(), 300);
 
             } else {
-                MessageUtils.sendAutoDeletedMessage("That event does not exist", 300, commandEvent.getChannel());
+                MessageUtils.sendAutoDeletedMessage("That event does not exist", 300, commandEvent);
             }
         } catch (RaidBotRuntimeException e) {
-            MessageUtils.sendAutoDeletedMessage("Error occurred while creating event.", 300, commandEvent.getChannel());
+            MessageUtils.sendAutoDeletedMessage("Error occurred while creating event.", 300, commandEvent);
         }
     }
 

--- a/src/main/java/com/bp3x/raidbot/commands/lfg/LFGCommand.java
+++ b/src/main/java/com/bp3x/raidbot/commands/lfg/LFGCommand.java
@@ -8,6 +8,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.requests.RestAction;
@@ -46,16 +47,16 @@ public class LFGCommand extends Command {
         ArrayList<Role> timezoneRoles = RaidBot.getConfig().getTimezoneRoles();
         Role userTimezoneRole = commandEvent.getMember().getRoles().stream().filter(timezoneRoles::contains).findFirst().orElse(null);
         if (userTimezoneRole == null) {
-            commandEvent.getChannel().sendMessage("You do not have a timezone role assigned. Ask an admin to give you your role.").queue();
+            MessageUtils.sendAutoDeletedMessage("You do not have a timezone role assigned. Ask an admin to give you your role.", 300, commandEvent.getChannel());
             return;
         }
 
         String[] args = commandEvent.getArgs().split("\\s+");
         if (args.length < 3) {
-            commandEvent.getChannel().sendMessage("Missing activity and/or date+time argument(s)").queue();
+            MessageUtils.sendAutoDeletedMessage("Missing activity and/or date+time argument(s)", 300, commandEvent.getChannel());
             return;
         } else if (args.length > 3) {
-            commandEvent.getChannel().sendMessage("Too many arguments. Should be in the format of: " + this.arguments).queue();
+            MessageUtils.sendAutoDeletedMessage("Too many arguments. Should be in the format of: " + this.arguments, 300, commandEvent.getChannel());;
             return;
         }
 
@@ -79,11 +80,11 @@ public class LFGCommand extends Command {
             eventDateTime = eventDateTime.withZoneSameInstant(ZoneId.of("GMT"));
 
             if (eventDateTime.isBefore(ZonedDateTime.now())) {
-                commandEvent.getChannel().sendMessage("Cannot schedule an event in the past.").queue();
+                MessageUtils.sendAutoDeletedMessage("Cannot schedule an event in the past.", 300, commandEvent.getChannel());
                 return;
             }
         } catch (DateTimeParseException e) {
-            commandEvent.getChannel().sendMessage("Invalid date/time argument.").queue();
+            MessageUtils.sendAutoDeletedMessage("Invalid date/time argument.", 300, commandEvent.getChannel());
             return;
         }
 
@@ -105,13 +106,13 @@ public class LFGCommand extends Command {
 
                 Event.scheduleEventDeletion(eventDateTime, commandEvent, success);
 
-                MessageUtils.deleteMessage(commandEvent.getMessage());
+                MessageUtils.autoDeleteMessage(commandEvent.getMessage(), 300);
 
             } else {
-                commandEvent.getChannel().sendMessage("That event does not exist").queue();
+                MessageUtils.sendAutoDeletedMessage("That event does not exist", 300, commandEvent.getChannel());
             }
         } catch (RaidBotRuntimeException e) {
-            commandEvent.getChannel().sendMessage("Error occurred while creating event.").queue();
+            MessageUtils.sendAutoDeletedMessage("Error occurred while creating event.", 300, commandEvent.getChannel());
         }
     }
 

--- a/src/main/java/com/bp3x/raidbot/commands/lfg/util/Event.java
+++ b/src/main/java/com/bp3x/raidbot/commands/lfg/util/Event.java
@@ -323,12 +323,10 @@ public class Event {
     public static void handleEventDeletionAndNotifyPlayers(CommandEvent commandEvent, Message embedMessage) throws RaidBotRuntimeException {
         Event event = plannedEventsList.get(embedMessage);
         StringBuilder builder = appendPlayerNames(event);
-        // send a notification to players that deletes in 15 mins
-        MessageUtils.sendAutoDeletedMessage(new MessageBuilder().append(builder.toString()).build(), 15, commandEvent.getChannel());
+        // send a notification to accepted and potentially tentative players
+        commandEvent.getChannel().sendMessage(new MessageBuilder().append(builder.toString()).build()).queue();
         // remove the event from the internal list and update the json
         removeEvent(embedMessage);
-        // delete the embed since we already notified players of importance
-        embedMessage.delete().queue();
     }
 
     /**

--- a/src/main/java/com/bp3x/raidbot/util/MessageUtils.java
+++ b/src/main/java/com/bp3x/raidbot/util/MessageUtils.java
@@ -1,5 +1,6 @@
 package com.bp3x.raidbot.util;
 
+import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageChannel;
 
@@ -13,15 +14,18 @@ public class MessageUtils {
     private MessageUtils() {
     }
 
+    private static MessageBuilder builder = new MessageBuilder();
+
     /**
      * Send a message and automatically delete it after provided time
      *
      * @param message - the message
-     * @param delay   - time delay in minutes before deletion
+     * @param delay   - time delay in seconds before deletion
      * @param channel - channel to send to
      */
-    public static void sendAutoDeletedMessage(Message message, int delay, MessageChannel channel) {
-        channel.sendMessage(message).queue(msg -> autoDeleteMessage(msg, delay));
+    public static void sendAutoDeletedMessage(String receivedMessage, int delay, MessageChannel channel) {
+        Message returnMessage = builder.append(receivedMessage).build();
+        channel.sendMessage(returnMessage).queue(msg -> autoDeleteMessage(msg, delay));
     }
 
     /**

--- a/src/main/java/com/bp3x/raidbot/util/MessageUtils.java
+++ b/src/main/java/com/bp3x/raidbot/util/MessageUtils.java
@@ -1,5 +1,6 @@
 package com.bp3x.raidbot.util;
 
+import com.jagrosh.jdautilities.command.CommandEvent;
 import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageChannel;
@@ -19,12 +20,14 @@ public class MessageUtils {
      *
      * @param receivedMessage - the message
      * @param delay   - time delay in seconds before deletion
-     * @param channel - channel to send to
+     * @param commandEvent - the event instance
      */
-    public static void sendAutoDeletedMessage(String receivedMessage, int delay, MessageChannel channel) {
+    public static void sendAutoDeletedMessage(String receivedMessage, int delay, CommandEvent commandEvent) {
         MessageBuilder builder = new MessageBuilder();
         Message returnMessage = builder.append(receivedMessage).build();
-        channel.sendMessage(returnMessage).queue(msg -> autoDeleteMessage(msg, delay));
+        commandEvent.getChannel().sendMessage(returnMessage).queue(msg -> autoDeleteMessage(msg, delay));
+        // auto delete the message instantiating the event as well
+        MessageUtils.autoDeleteMessage(commandEvent.getMessage(), delay);
     }
 
     /**

--- a/src/main/java/com/bp3x/raidbot/util/MessageUtils.java
+++ b/src/main/java/com/bp3x/raidbot/util/MessageUtils.java
@@ -14,16 +14,15 @@ public class MessageUtils {
     private MessageUtils() {
     }
 
-    private static MessageBuilder builder = new MessageBuilder();
-
     /**
      * Send a message and automatically delete it after provided time
      *
-     * @param message - the message
+     * @param receivedMessage - the message
      * @param delay   - time delay in seconds before deletion
      * @param channel - channel to send to
      */
     public static void sendAutoDeletedMessage(String receivedMessage, int delay, MessageChannel channel) {
+        MessageBuilder builder = new MessageBuilder();
         Message returnMessage = builder.append(receivedMessage).build();
         channel.sendMessage(returnMessage).queue(msg -> autoDeleteMessage(msg, delay));
     }

--- a/src/main/java/com/bp3x/raidbot/util/MessageUtils.java
+++ b/src/main/java/com/bp3x/raidbot/util/MessageUtils.java
@@ -19,15 +19,26 @@ public class MessageUtils {
      * Send a message and automatically delete it after provided time
      *
      * @param receivedMessage - the message
-     * @param delay   - time delay in seconds before deletion
-     * @param commandEvent - the event instance
+     * @param delay           - time delay in seconds before deletion
+     * @param channel         - the channel to delete from
      */
-    public static void sendAutoDeletedMessage(String receivedMessage, int delay, CommandEvent commandEvent) {
+    public static void sendAutoDeletedMessage(String receivedMessage, int delay, MessageChannel channel) {
         MessageBuilder builder = new MessageBuilder();
         Message returnMessage = builder.append(receivedMessage).build();
-        commandEvent.getChannel().sendMessage(returnMessage).queue(msg -> autoDeleteMessage(msg, delay));
-        // auto delete the message instantiating the event as well
-        MessageUtils.autoDeleteMessage(commandEvent.getMessage(), delay);
+        channel.sendMessage(returnMessage).queue(msg -> autoDeleteMessage(msg, delay));
+    }
+
+    /**
+     * Use this function to delete both the target message and the commandEvent that spawned the message.
+     * Ex: good for bot error responses that will also require cleanup of the original command.
+     *
+     * @param receivedMessage - the message
+     * @param delay - time delay in seconds before deletion
+     * @param commandEvent - the command event whose start message we wish to delete
+     */
+    public static void sendAutoDeletedMessage(String receivedMessage, int delay, CommandEvent commandEvent) {
+        sendAutoDeletedMessage(receivedMessage, delay, commandEvent.getChannel());
+        autoDeleteMessage(commandEvent.getMessage(), delay);
     }
 
     /**
@@ -38,14 +49,5 @@ public class MessageUtils {
      */
     public static void autoDeleteMessage(Message message, int delay) {
         message.delete().queueAfter(delay, TimeUnit.SECONDS);
-    }
-
-    /**
-     * Delete a message 15 seconds after execution
-     *
-     * @param message - the message to delete
-     */
-    public static void deleteMessage(Message message) {
-        message.delete().queueAfter(15, TimeUnit.SECONDS);
     }
 }


### PR DESCRIPTION
Most error messages and the command that triggered them now delete 5 minutes after execution.

The ping to remind players the event is starting and it's embed no longer delete.